### PR TITLE
update patch for lmic v3.2

### DIFF
--- a/patch/arduino-lmic-stm32-patch.txt
+++ b/patch/arduino-lmic-stm32-patch.txt
@@ -1,8 +1,8 @@
 diff --git a/src/hal/hal.cpp b/src/hal/hal.cpp
-index 7791c20..ac24669 100644
+index 6e72a58..0b5cddd 100644
 --- a/src/hal/hal.cpp
 +++ b/src/hal/hal.cpp
-@@ -284,6 +284,31 @@ u1_t hal_checkTimer (u4_t time) {
+@@ -334,6 +334,31 @@ u1_t hal_checkTimer (u4_t time) {
      return delta_time(time) <= 0;
  }
  
@@ -26,7 +26,7 @@ index 7791c20..ac24669 100644
 +}
 +
 +void hal_enableIRQs () {
-+    hal_io_check();
++    hal_pollPendingIRQs_helper();
 +}
 +
 +#else /* ARDUINO_ARCH_STM32 */
@@ -34,7 +34,7 @@ index 7791c20..ac24669 100644
  static uint8_t irqlevel = 0;
  
  void hal_disableIRQs () {
-@@ -311,6 +336,8 @@ uint8_t hal_getIrqLevel(void) {
+@@ -365,6 +390,8 @@ uint8_t hal_getIrqLevel(void) {
      return irqlevel;
  }
  


### PR DESCRIPTION
`void hal_io_check()` has been renamed to `void hal_pollPendingIRQs_helper` in commit https://github.com/mcci-catena/arduino-lmic/commit/e2d6f4851087d6b4ae0b4e2e55415ba7c57ad262#diff-7cce30ca97b97ac6a31ad515b700e604